### PR TITLE
Fixed incorrect build action for Models and WebApiController templates

### DIFF
--- a/src/ItemTemplates/Angular/WebApiController.tst
+++ b/src/ItemTemplates/Angular/WebApiController.tst
@@ -1,6 +1,6 @@
 ﻿${
     using System.Text.RegularExpressions;
-        
+    using Typewriter.Extensions.WebApi;
      
     //TODO: Manage AcceptVerbAttribute
     string Verb(Method m) {
@@ -39,8 +39,6 @@
        routePrefix = routePrefix  ?? $"api/{parent.name.Replace("Controller", "")}/";
 
        return routePrefix + route;
-
-       
     }
     
 
@@ -57,7 +55,7 @@
 
     string Params(Method m)
     { 
-        var route = Extensions.Route(m)??""; 
+        var route = m.Route()??""; 
       
         var parameters = m.Parameters
                 .Where(p=>p.name != "id")
@@ -77,7 +75,7 @@
         var parameters = Params(m);
         var data = Data(m);
 
-        var result = $"{{ url: `{url}`, method: \"{method}\", params: {parameters}, data: {data} }}";
+        var result = $"{{ url: '{url}', method: \"{method}\", params: {parameters}, data: {data} }}";
         result = result.Replace(", params: null", "");
         result = result.Replace(", data: null", "");
 

--- a/src/ItemTemplates/Typewriter.ItemTemplates.csproj
+++ b/src/ItemTemplates/Typewriter.ItemTemplates.csproj
@@ -118,29 +118,30 @@
     </VSTemplate>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Models\ModelsCSharp.vstemplate">
+    <VSTemplate Include="Models\ModelsCSharp.vstemplate">
       <OutputSubPath>Web/Scripts/TypeScript Templates</OutputSubPath>
-    </None>
+    </VSTemplate>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Models\ModelsWeb.vstemplate">
+    <VSTemplate Include="Models\ModelsWeb.vstemplate">
       <OutputSubPath>Web/Scripts/TypeScript Templates</OutputSubPath>
-    </None>
+      <SubType>Designer</SubType>
+    </VSTemplate>
   </ItemGroup>
   <ItemGroup>
     <None Include="Models\tst.ico" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Angular\WebApiControllerCSharp.vstemplate">
+    <VSTemplate Include="Angular\WebApiControllerCSharp.vstemplate">
       <SubType>Designer</SubType>
       <OutputSubPath>Web/Scripts/TypeScript Templates</OutputSubPath>
-    </None>
+    </VSTemplate>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Angular\WebApiControllerWeb.vstemplate">
+    <VSTemplate Include="Angular\WebApiControllerWeb.vstemplate">
       <SubType>Designer</SubType>
       <OutputSubPath>Web/Scripts/TypeScript Templates</OutputSubPath>
-    </None>
+    </VSTemplate>
   </ItemGroup>
   <ItemGroup>
     <None Include="Angular\tst.ico" />


### PR DESCRIPTION
Fixed incorrect build action for Models and WebApiController templates, because Build Action was None templates were not visible when adding new item.