### PR TITLE
Convert wildcard parameters

### DIFF
--- a/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
+++ b/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
@@ -127,7 +127,7 @@ namespace Typewriter.Extensions.WebApi
 
         private static string ConvertRouteParameters(string route)
         {
-            return Regex.Replace(route, @"\{(\w+):?\w*\??\}", m => $"${{{m.Groups[1].Value}}}");
+            return Regex.Replace(route, @"\{\*?(\w+):?\w*\??\}", m => $"${{{m.Groups[1].Value}}}");
         }
 
         private static string AppendQueryString(Method method, string route)


### PR DESCRIPTION
The situation is that `[Route("search/{*key}")]` will be rendered as `search/{*key}` instead of 'search/${key}' because the asterisk (*) is not considered to exist.
This change is necessary because my key may contain slashes (`a/b/c`) and only the wildcard parameter can catch these kind of values.

I updated the regex to allow the existence of an optional single asterisk and tested the change.

It would be awesome if it would be included in <strike>V1.4</strike> V1.5 :+1: 
Thank you!