### PR TITLE
Feature: log thrown exception

### DIFF
--- a/src/Typewriter/Generation/Parser.cs
+++ b/src/Typewriter/Generation/Parser.cs
@@ -95,8 +95,8 @@ namespace Typewriter.Generation
                                             items = new Item[0];
                                             hasError = true;
 
-                                            var message = $"Error rendering template. Cannot apply filter to identifier '{identifier}'. {e.Message} Source path: {sourcePath}";
-                                            LogException(e, message, projectItem);
+                                            var message = $"Error rendering template. Cannot apply filter to identifier '{identifier}'.";
+                                            LogException(e, message, projectItem, sourcePath);
                                         }
                                     }
                                     else
@@ -189,14 +189,14 @@ namespace Typewriter.Generation
             {
                 hasError = true;
 
-                var message = $"Error rendering template. Cannot get identifier '{identifier}'. {e.Message} Source path: {sourcePath}";
-                LogException(e, message, projectItem);
+                var message = $"Error rendering template. Cannot get identifier '{identifier}'.";
+                LogException(e, message, projectItem, sourcePath);
             }
 
             return false;
         }
 
-        private void LogException(Exception exception, string message, ProjectItem projectItem)
+        private void LogException(Exception exception, string message, ProjectItem projectItem, string sourcePath)
         {
             // skip the target invokation exception, get the real exception instead.
             if (exception is TargetInvocationException && exception.InnerException != null)
@@ -204,9 +204,11 @@ namespace Typewriter.Generation
                 exception = exception.InnerException;
             }
 
-            var logMessage = message = $"{message}{Environment.NewLine}{exception}";
+            var studioMessage = $"{message} Error: {exception.Message}. Source path: {sourcePath}. See Typewriter output for more detail.";
+            var logMessage = $"{message} Source path: {sourcePath}{Environment.NewLine}{exception}";
+            
             Log.Error(logMessage);
-            ErrorList.AddError(projectItem, message);
+            ErrorList.AddError(projectItem, studioMessage);
             ErrorList.Show();
         }
     }

--- a/src/Typewriter/Generation/Parser.cs
+++ b/src/Typewriter/Generation/Parser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using EnvDTE;
 using Typewriter.CodeModel;
 using Typewriter.TemplateEditor.Lexing;
@@ -95,10 +96,7 @@ namespace Typewriter.Generation
                                             hasError = true;
 
                                             var message = $"Error rendering template. Cannot apply filter to identifier '{identifier}'. {e.Message} Source path: {sourcePath}";
-
-                                            Log.Error(message);
-                                            ErrorList.AddError(projectItem, message);
-                                            ErrorList.Show();
+                                            LogException(e, message, projectItem);
                                         }
                                     }
                                     else
@@ -192,13 +190,24 @@ namespace Typewriter.Generation
                 hasError = true;
 
                 var message = $"Error rendering template. Cannot get identifier '{identifier}'. {e.Message} Source path: {sourcePath}";
-
-                Log.Error(message);
-                ErrorList.AddError(projectItem, message);
-                ErrorList.Show();
+                LogException(e, message, projectItem);
             }
 
             return false;
+        }
+
+        private void LogException(Exception exception, string message, ProjectItem projectItem)
+        {
+            // skip the target invokation exception, get the real exception instead.
+            if (exception is TargetInvocationException && exception.InnerException != null)
+            {
+                exception = exception.InnerException;
+            }
+
+            var logMessage = message = $"{message}{Environment.NewLine}{exception}";
+            Log.Error(logMessage);
+            ErrorList.AddError(projectItem, message);
+            ErrorList.Show();
         }
     }
 }


### PR DESCRIPTION
It's pretty hard to get a clue where in your template an exception was thrown.
The usual way is to test/disable each and every custom method and wait if you got the error.
Or you wrap your output of a method (only if it's a string) with a try/catch and return the exception's message.

This is pretty cumbersome.

I enhanced the logging of the errors in the Parser to log the exception as a whole.

Comparision:

OLD:
```
ERROR: Error rendering template. Cannot get identifier 'getTypeName'. Exception has been thrown by the target of an invocation. Source path: C:\Project\SomeFile.cs
```

NEW:
```
ERROR: Error rendering template. Cannot get identifier 'getTypeName'. Exception has been thrown by the target of an invocation. Source path: C:\Project\SomeFile.cs
System.InvalidOperationException: Oh oh, something happend here. where is the callstack? ---> System.Exception: Inner exception text for demonstration
   --- End of inner exception stack trace ---
   at __Typewriter.Template.getInterfaceName(String name)
   at __Typewriter.Template.getTypeName(Class c)
```
Notice the callstack which really points me the way where the exception was thrown.
`getInterfaceName` and `getTypeName` do exist in my template.

I hope you will accept the PR because it makes it so much easier to find errors.

The modification of the logging only changes the behavior of the Output window, not the errors in the visual studio error list for now.

Should the same error be shown in the error list as well?