### PR TITLE
make ko.observable* calls include generic type

### DIFF
--- a/pages/examples.html
+++ b/pages/examples.html
@@ -85,8 +85,8 @@ ${
         var type = property.Type;
 
         return type.IsEnumerable ?
-            $"KnockoutObservableArray&lt;{type.Name.TrimEnd('[', ']')}&gt; = ko.observableArray({type.Default()})" :
-            $"KnockoutObservable&lt;{type.Name}&gt; = ko.observable({type.Default()})";
+            $"KnockoutObservableArray&lt;{type.Name.TrimEnd('[', ']')}&gt; = ko.observableArray&lt;{type.Name.TrimEnd('[', ']')}&gt;({type.Default()})" :
+            $"KnockoutObservable&lt;{type.Name}&gt; = ko.observable&lt;{type.Name}&gt;({type.Default()})";
     }
 
     string TypeMap(Property property)


### PR DESCRIPTION
Without this, I was getting failures - seems to make sense to include the generic type parameter for both in any case.

http://i.imgur.com/Ty3mwgK.png