### PR TITLE
Broaden install targets to include VS15 Preview

### DIFF
--- a/src/Typewriter/source.extension.vsixmanifest
+++ b/src/Typewriter/source.extension.vsixmanifest
@@ -13,9 +13,9 @@
     <Tags>TypeScript, Code Generation, Templates, Web API, MVC, Typewriter</Tags>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
While currently still in a fairly early preview stage, preview 4 to be exact, VS15 is already quite polished and offers some extra niceties for TypeScript projects including opening a folder as a solution. This change allows the extension to be discovered and installed into any version of VS15. Thank you.