### PR TITLE
Filter CancellationToken before generating RequestData

### DIFF
--- a/src/CodeModel/Extensions/WebApi/RequestDataExtensions.cs
+++ b/src/CodeModel/Extensions/WebApi/RequestDataExtensions.cs
@@ -24,7 +24,9 @@ namespace Typewriter.Extensions.WebApi
         public static string RequestData(this Method method, string route)
         {
             var url = method.Url(route);
-            var dataParameters = method.Parameters.Where(p => url.Contains($"${{{p.Name}}}") == false).ToList();
+
+            // CancellationToken will never be send from TypeScript, filter them out before generating RequestData
+            var dataParameters = method.Parameters.Where(x => x.Type.Name != "CancellationToken").Where(p => url.Contains($"${{{p.Name}}}") == false).ToList();
 
             if (dataParameters.Count == 1)
             {


### PR DESCRIPTION
Controller that take a CancellationToken parameter cause a wrong $RequestData object to be generated. e.g. this: 

```csharp
[HttpPost]
public async Task<IHttpActionResult> Create(string data, CancellationToken cancellationToken)
```
leads to a $RequestData object that is "cancellationToken". 

The PR fixes this by filtering out all parameters that are of type CancellationToken.