### PR TITLE
Default route with method attribute returned wrong url

### DIFF
--- a/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
+++ b/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
@@ -69,7 +69,7 @@ namespace Typewriter.Extensions.WebApi
                 if (string.IsNullOrEmpty(value))
                 {
                     // Todo: What happens with empty route and no route prefix?
-                    route = routePrefix ?? string.Empty;
+                    route = routePrefix ?? route;
                 }
                 else if (value.StartsWith("~"))
                 {

--- a/src/Tests/Extensions/Support/RouteLessController.cs
+++ b/src/Tests/Extensions/Support/RouteLessController.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Typewriter.Tests.Support;
+
+namespace Typewriter.Tests.Extensions.Support
+{
+    public class RouteLessController
+    {
+        [HttpGet]
+        public void Test(int id)
+        {
+            
+        }
+
+        public void Test2(int id)
+        {
+        }
+
+        public void Test3()
+        {
+        }
+
+
+    }
+}

--- a/src/Tests/Extensions/WebApiRouteTests.cs
+++ b/src/Tests/Extensions/WebApiRouteTests.cs
@@ -61,6 +61,15 @@ namespace Typewriter.Tests.Extensions
             methodInfo.Url().ShouldEqual("api/RouteLess/");
         }
 
+        [Fact]
+        public void Expect_to_route_on_routless_Controller_with_methodattribute_and_inputparam_custom_route()
+        {
+            var classInfo = routeLessControllerInfo.Classes.First();
+            var methodInfo = classInfo.Methods.First(p => p.Name == "Test");
+
+            methodInfo.Url("api/{controller}/{action}/{id?}").ShouldEqual("api/RouteLess/test/${id}");
+        }
+
 
         [Fact]
         public void Expect_to_find_parameters_on_wildcard_route_url()

--- a/src/Tests/Extensions/WebApiRouteTests.cs
+++ b/src/Tests/Extensions/WebApiRouteTests.cs
@@ -26,11 +26,41 @@ namespace Typewriter.Tests.Extensions
     public abstract class WebApiRouteExtensionsTests : TestBase
     {
         private readonly File fileInfo;
+        private readonly File routeLessControllerInfo;
 
         protected WebApiRouteExtensionsTests(ITestFixture fixture) : base(fixture)
         {
             fileInfo = GetFile(@"Tests\Extensions\Support\RouteController.cs");
+            routeLessControllerInfo = GetFile(@"Tests\Extensions\Support\RouteLessController.cs");
         }
+
+        [Fact]
+        public void Expect_to_route_on_routless_Controller_with_methodattribute()
+        {
+            var classInfo = routeLessControllerInfo.Classes.First();
+            var methodInfo = classInfo.Methods.First(p => p.Name == "Test");
+
+            methodInfo.Url().ShouldEqual("api/RouteLess/${id}");
+        }
+
+        [Fact]
+        public void Expect_to_route_on_routless_Controller_without_methodattribute()
+        {
+            var classInfo = routeLessControllerInfo.Classes.First();
+            var methodInfo = classInfo.Methods.First(p => p.Name == "Test2");
+
+            methodInfo.Url().ShouldEqual("api/RouteLess/${id}");
+        }
+
+        [Fact]
+        public void Expect_to_route_on_routless_Controller_without_methodattribute_and_inputparam()
+        {
+            var classInfo = routeLessControllerInfo.Classes.First();
+            var methodInfo = classInfo.Methods.First(p => p.Name == "Test3");
+
+            methodInfo.Url().ShouldEqual("api/RouteLess/");
+        }
+
 
         [Fact]
         public void Expect_to_find_parameters_on_wildcard_route_url()

--- a/src/Tests/Typewriter.Tests.csproj
+++ b/src/Tests/Typewriter.Tests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Extensions\Support\InheritedController.cs" />
     <Compile Include="Extensions\Support\RouteControllerWithDefaultRoute.cs" />
     <Compile Include="Extensions\Support\RouteController.cs" />
+    <Compile Include="Extensions\Support\RouteLessController.cs" />
     <Compile Include="Extensions\WebApiRouteTestsClassRoute.cs" />
     <Compile Include="Extensions\WebApiRouteTests.cs" />
     <Compile Include="Extensions\WebApiTests.cs" />


### PR DESCRIPTION
for #218 this fixes the url for the default route on a method with an attribute.
also added a unit test for generating an url where you can give your own route template
