### PR TITLE
Fix GetRoutePrefix issue

### DIFF
--- a/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
+++ b/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
@@ -98,11 +98,11 @@ namespace Typewriter.Extensions.WebApi
                 return null;
             }
 
-            var routePrefix = @class?.Attributes.FirstOrDefault(a => a.Name == "RoutePrefix")?.Value.TrimEnd('/');
+            var routePrefix = @class?.Attributes.FirstOrDefault(a => a.Name == "RoutePrefix")?.Value?.TrimEnd('/');
 
             if (String.IsNullOrEmpty(routePrefix))
             {
-                routePrefix = @class?.Attributes.FirstOrDefault(a => a.Name == "Route")?.Value.TrimEnd('/');
+                routePrefix = @class?.Attributes.FirstOrDefault(a => a.Name == "Route")?.Value?.TrimEnd('/');
             }
 
             if (String.IsNullOrEmpty(routePrefix) && @class.BaseClass != null)


### PR DESCRIPTION
Fix to GetRoutePrefix to prevent occasional null reference errors. Issue exposes itself as messages indicating that $Url and $RequestData aren't accessible.