### PR TITLE
Support for referencing external assemblies in template code

### DIFF
--- a/src/Typewriter/Generation/Compiler.cs
+++ b/src/Typewriter/Generation/Compiler.cs
@@ -22,7 +22,15 @@ namespace Typewriter.Generation
             {
                 var asmSourcePath = assembly.Location;
                 var asmDestPath = Path.Combine(Constants.TempDirectory, Path.GetFileName(asmSourcePath));
-                File.Copy(asmSourcePath, asmDestPath, true);
+                try
+                {
+                    //File may be in use
+                    File.Copy(asmSourcePath, asmDestPath, true);
+                }
+                catch (Exception e)
+                {
+                    Log.Warn(e.ToString());
+                }
             }
 
             var filname = Path.GetRandomFileName();

--- a/src/Typewriter/Generation/Compiler.cs
+++ b/src/Typewriter/Generation/Compiler.cs
@@ -20,6 +20,8 @@ namespace Typewriter.Generation
 
             foreach (Assembly assembly in shadowClass.ReferencedAssemblies)
             {
+                if (assembly.GlobalAssemblyCache) continue;
+
                 var asmSourcePath = assembly.Location;
                 var asmDestPath = Path.Combine(Constants.TempDirectory, Path.GetFileName(asmSourcePath));
                 try

--- a/src/Typewriter/Generation/Compiler.cs
+++ b/src/Typewriter/Generation/Compiler.cs
@@ -18,6 +18,13 @@ namespace Typewriter.Generation
                 Directory.CreateDirectory(Constants.TempDirectory);
             }
 
+            foreach (Assembly assembly in shadowClass.ReferencedAssemblies)
+            {
+                var asmSourcePath = assembly.Location;
+                var asmDestPath = Path.Combine(Constants.TempDirectory, Path.GetFileName(asmSourcePath));
+                File.Copy(asmSourcePath, asmDestPath, true);
+            }
+
             var filname = Path.GetRandomFileName();
             var path = Path.Combine(Constants.TempDirectory, filname);
 

--- a/src/Typewriter/Generation/TemplateCodeParser.cs
+++ b/src/Typewriter/Generation/TemplateCodeParser.cs
@@ -186,6 +186,9 @@ namespace Typewriter.Generation
                     var path = stream.PeekBlock(identifier.Length + 2, '(', ')');
                     if (path != null)
                     {
+                        int pathLen = path.Length;
+                        path = path.Trim('"');
+
                         try
                         {
                             var absPath = Path.IsPathRooted(path)
@@ -193,12 +196,15 @@ namespace Typewriter.Generation
                                 : Path.Combine(Path.GetDirectoryName(projectItem.Path()) ?? "", path);
 
                             shadowClass.AddReference(absPath);
-                            stream.Advance(path.Length + 2 + identifier.Length);
                             return true;
                         }
                         catch (Exception ex)
                         {
                             Log.Error("Reference Error: " + ex);
+                        }
+                        finally
+                        {
+                            stream.Advance(pathLen + 2 + identifier.Length);
                         }
                     }
                 }

--- a/src/Typewriter/Generation/TemplateCodeParser.cs
+++ b/src/Typewriter/Generation/TemplateCodeParser.cs
@@ -183,16 +183,17 @@ namespace Typewriter.Generation
                 var identifier = stream.PeekWord(1);
                 if (identifier == "Reference")
                 {
-                    var path = stream.PeekBlock(identifier.Length + 2, '(', ')');
-                    if (path != null)
+                    var reference = stream.PeekBlock(identifier.Length + 2, '(', ')');
+                    if (reference != null)
                     {
-                        int pathLen = path.Length;
-                        path = path.Trim('"');
+                        var len = reference.Length;
+                        reference = reference.Trim('"');
                         try
                         {
-                            path = PathResolver.ResolveRelative(path, templateProjectItem);
+                            if (reference.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                                reference = PathResolver.ResolveRelative(reference, templateProjectItem);
 
-                            shadowClass.AddReference(path);
+                            shadowClass.AddReference(reference);
                             return true;
                         }
                         catch (Exception ex)
@@ -201,7 +202,7 @@ namespace Typewriter.Generation
                         }
                         finally
                         {
-                            stream.Advance(pathLen + 2 + identifier.Length);
+                            stream.Advance(len + 2 + identifier.Length);
                         }
                     }
                 }

--- a/src/Typewriter/Generation/TemplateCodeParser.cs
+++ b/src/Typewriter/Generation/TemplateCodeParser.cs
@@ -178,32 +178,30 @@ namespace Typewriter.Generation
 
         private static bool ParseReference(Stream stream, ShadowClass shadowClass, ProjectItem templateProjectItem)
         {
-            if (stream.Current == '$')
-            {
-                var identifier = stream.PeekWord(1);
-                if (identifier == "Reference")
-                {
-                    var reference = stream.PeekBlock(identifier.Length + 2, '(', ')');
-                    if (reference != null)
-                    {
-                        var len = reference.Length;
-                        reference = reference.Trim('"');
-                        try
-                        {
-                            if (reference.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                                reference = PathResolver.ResolveRelative(reference, templateProjectItem);
+            const string keyword = "reference";
 
-                            shadowClass.AddReference(reference);
-                            return true;
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Error("Reference Error: " + ex);
-                        }
-                        finally
-                        {
-                            stream.Advance(len + 2 + identifier.Length);
-                        }
+            if (stream.Current == '#' && stream.Peek() == keyword[0] && stream.PeekWord(1) == keyword)
+            {
+                var reference = stream.PeekLine(keyword.Length + 1);
+                if (reference != null)
+                {
+                    var len = reference.Length + keyword.Length + 1;
+                    reference = reference.Trim('"', ' ', '\n', '\r');
+                    try
+                    {
+                        if (reference.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                            reference = PathResolver.ResolveRelative(reference, templateProjectItem);
+
+                        shadowClass.AddReference(reference);
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error("Reference Error: " + ex);
+                    }
+                    finally
+                    {
+                        stream.Advance(len - 1);
                     }
                 }
             }

--- a/src/Typewriter/TemplateEditor/Controllers/CompletionController.cs
+++ b/src/Typewriter/TemplateEditor/Controllers/CompletionController.cs
@@ -311,7 +311,7 @@ namespace Typewriter.TemplateEditor.Controllers
                     {
                         Filter();
                     }
-                    else
+                    else if (textView != null)
                     {
                         var ch = GetTypeChar(pvaIn);
 

--- a/src/Typewriter/TemplateEditor/Editor.cs
+++ b/src/Typewriter/TemplateEditor/Editor.cs
@@ -40,10 +40,15 @@ namespace Typewriter.TemplateEditor
 
             var code = currentSnapshot.GetText();
 
-            codeLexer.Tokenize(semanticModelCache, code);
+            codeLexer.Tokenize(semanticModelCache, code, GetFilePath(buffer));
             templateLexer.Tokenize(semanticModelCache, code);
-            
+
             return semanticModelCache;
+        }
+
+        private static string GetFilePath(ITextBuffer textBuffer)
+        {
+            return textBuffer.Properties.TryGetProperty<ITextDocument>(typeof(ITextDocument), out var doc) ? doc.FilePath : null;
         }
 
         // Outlining
@@ -100,7 +105,7 @@ namespace Typewriter.TemplateEditor
         {
             var tokens = GetSemanticModel(buffer);
             var type = tokens.GetContextSpan(point).Type;
-            
+
             return type == ContextType.CodeBlock || type == ContextType.Lambda;
         }
 

--- a/src/Typewriter/TemplateEditor/Lexing/CodeLexer.cs
+++ b/src/Typewriter/TemplateEditor/Lexing/CodeLexer.cs
@@ -60,30 +60,28 @@ namespace Typewriter.TemplateEditor.Lexing
 
         private void ParseReference(Stream stream)
         {
-            if (stream.Current == '$')
+            const string keyword = "reference";
+
+            if (stream.Current == '#' && stream.Peek() == keyword[0] && stream.PeekWord(1) == keyword)
             {
-                var identifier = stream.PeekWord(1);
-                if (identifier == "Reference")
+                var reference = stream.PeekLine(keyword.Length + 1);
+                if (reference != null)
                 {
-                    var reference = stream.PeekBlock(identifier.Length + 2, '(', ')');
-                    if (reference != null)
+                    var len = reference.Length + keyword.Length + 1;
+                    reference = reference.Trim('"', ' ', '\n', '\r');
+                    try
                     {
-                        var len = reference.Length;
-                        reference = reference.Trim('"');
-                        try
-                        {
-                            if (reference.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                                reference = PathResolver.ResolveRelative(reference, this.templateProjectItem);
+                        if (reference.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                            reference = PathResolver.ResolveRelative(reference, this.templateProjectItem);
 
-                            semanticModel.ShadowClass.AddReference(reference);
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Debug("Reference Error: " + ex.Message);
-                        }
-
-                        stream.Advance(len + 2 + identifier.Length);
+                        semanticModel.ShadowClass.AddReference(reference);
                     }
+                    catch (Exception ex)
+                    {
+                        Log.Debug("Reference Error: " + ex.Message);
+                    }
+
+                    stream.Advance(len - 1);
                 }
             }
         }

--- a/src/Typewriter/TemplateEditor/Lexing/Roslyn/ShadowClass.cs
+++ b/src/Typewriter/TemplateEditor/Lexing/Roslyn/ShadowClass.cs
@@ -68,9 +68,11 @@ namespace Typewriter.TemplateEditor.Lexing.Roslyn
             workspace.SetMetadataReferences(documentId, referencedAssemblies);
         }
 
-        public void AddReference(string path)
+        public void AddReference(string pathOrName)
         {
-            var asm = Assembly.LoadFile(path);
+            var asm = pathOrName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                ? Assembly.LoadFile(pathOrName)
+                : Assembly.Load(pathOrName);
             if (referencedAssemblies.Add(asm))
                 workspace.SetMetadataReferences(documentId, referencedAssemblies);
         }

--- a/src/Typewriter/TemplateEditor/Lexing/Roslyn/ShadowClass.cs
+++ b/src/Typewriter/TemplateEditor/Lexing/Roslyn/ShadowClass.cs
@@ -41,19 +41,26 @@ namespace Typewriter.TemplateEditor.Lexing.Roslyn
         private readonly ShadowWorkspace workspace;
         private readonly DocumentId documentId;
         private readonly List<Snippet> snippets = new List<Snippet>();
-        
+        private readonly List<Assembly> referencedAssemblies = new List<Assembly>();
         private int offset;
         private bool classAdded;
-        
+
         public ShadowClass()
         {
+            referencedAssemblies.Add(typeof(Class).Assembly);
             workspace = new ShadowWorkspace();
             documentId = workspace.AddProjectWithDocument("ShadowClass.cs", "");
         }
 
         public IEnumerable<Snippet> Snippets => snippets;
 
-        public IEnumerable<Assembly> ReferencedAssemblies => new[] { typeof (Class).Assembly };
+        public IEnumerable<Assembly> ReferencedAssemblies => referencedAssemblies;
+
+        public void AddReference(string path)
+        {
+            var asm = Assembly.LoadFile(path);
+            referencedAssemblies.Add(asm);
+        }
 
         public void AddUsing(string code, int startIndex)
         {
@@ -239,6 +246,7 @@ namespace Typewriter.TemplateEditor.Lexing.Roslyn
         public EmitResult Compile(string outputPath)
         {
             workspace.ChangeAllMethodsToPublicStatic(documentId);
+            workspace.AddMetadataReferences(documentId, ReferencedAssemblies);
             return workspace.Compile(documentId, outputPath);
         }
 

--- a/src/Typewriter/Typewriter.csproj
+++ b/src/Typewriter/Typewriter.csproj
@@ -333,6 +333,7 @@
     <Compile Include="TemplateEditor\Lexing\Tokens.cs" />
     <Compile Include="VisualStudio\ContextMenu\RenderTemplate.cs" />
     <Compile Include="VisualStudio\ErrorList.cs" />
+    <Compile Include="VisualStudio\PathResolver.cs" />
     <Compile Include="VisualStudio\ThemeInfo.cs" />
     <Compile Include="TemplateEditor\Controllers\BraceMatchingController.cs" />
     <Compile Include="TemplateEditor\FormatDefinitions\PropertyFormatDefinition.cs" />

--- a/src/Typewriter/VisualStudio/ExtensionPackage.cs
+++ b/src/Typewriter/VisualStudio/ExtensionPackage.cs
@@ -40,6 +40,8 @@ namespace Typewriter.VisualStudio
         /// </summary>
         internal static ExtensionPackage Instance { get; private set; }
 
+        internal DTE Dte => dte;
+
         public TypewriterOptionsPage Options => (TypewriterOptionsPage) GetDialogPage(typeof (TypewriterOptionsPage));
 
         /// <summary>

--- a/src/Typewriter/VisualStudio/PathResolver.cs
+++ b/src/Typewriter/VisualStudio/PathResolver.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using EnvDTE;
+
+namespace Typewriter.VisualStudio
+{
+    public static class PathResolver
+    {
+        public static string ResolveRelative(string path, ProjectItem projectItem)
+        {
+            if (path == null)
+                throw new ArgumentNullException(nameof(path));
+
+            if (Path.IsPathRooted(path) || projectItem == null) return path;
+
+            if (path.StartsWith("~\\"))
+            {
+                var folder = Path.GetDirectoryName(projectItem.ContainingProject.FullName);
+                return Path.Combine(folder, path.Substring(2));
+            }
+            else if (path.StartsWith("~~\\"))
+            {
+                var folder = Path.GetDirectoryName(projectItem.DTE.Solution.FullName);
+                return Path.Combine(folder, path.Substring(3));
+            }
+            else
+            {
+                var folder = Path.GetDirectoryName(projectItem.Document.Path);
+                return Path.Combine(folder, path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi @frhagn,

I did my best to follow along your code without changing it too much and I think I have a decent starting point for a PR here :)

You can reference and use any assembly with either an absolute path or a relative one. For example:

`$Reference("D:\Dev\MyAsm.dll")`
`$Reference("tools\MyAsm.dll")`  // relative to the template
`$Reference("~\tools\MyAsm.dll")`  // relative to the project's root
`$Reference("~~\ProjectB\tools\MyAsm.dll")`  // relative to the solution's root.

The new directive must be placed at the beginning of the file.

I'm still not 100% sure about the syntax `$Reference("...")`, I would rather prefer something like `#reference "..."`, what do you think?

Also:
- no support for referencing framework's assemblies yet;
- the renderer loads those assemblies from temp directory, where they are copied, and of course it doesn't release them afterwards. So if you change (recompile?) a referenced assembly then the next render is unable to copy the new file to the temp directory :(

I thought about using a separate AppDomain for the rendering process, but I wanted your feedback before embarking in such a big change.

Let me know,

-Rodrigo-