### PR TITLE
Added the ability to get type arguments passed to attribute

### DIFF
--- a/src/CodeDom/CodeDomAttributeMetadata.cs
+++ b/src/CodeDom/CodeDomAttributeMetadata.cs
@@ -24,6 +24,8 @@ namespace Typewriter.Metadata.CodeDom
         public string FullName => codeAttribute.FullName;
         public string Value => value;
 
+        public IEnumerable<IAttributeArgumentMetadata> Arguments => throw new System.NotSupportedException();
+
         internal static IEnumerable<IAttributeMetadata> FromCodeElements(CodeElements codeElements)
         {
             return codeElements.OfType<CodeAttribute2>().Select(a => new CodeDomAttributeMetadata(a));

--- a/src/CodeModel/CodeModel/Attribute.cs
+++ b/src/CodeModel/CodeModel/Attribute.cs
@@ -1,4 +1,5 @@
-﻿using Typewriter.CodeModel.Attributes;
+﻿using System.Collections.Generic;
+using Typewriter.CodeModel.Attributes;
 
 namespace Typewriter.CodeModel
 {
@@ -22,7 +23,7 @@ namespace Typewriter.CodeModel
         /// The name of the attribute.
         /// </summary>
         public abstract string Name { get; }
-        
+
         /// <summary>
         /// The parent context of the attribute.
         /// </summary>
@@ -34,9 +35,14 @@ namespace Typewriter.CodeModel
         public abstract string Value { get; }
 
         /// <summary>
+        /// The arguments of the attribute.
+        /// </summary>
+        public abstract IEnumerable<AttributeArgument> Arguments { get; }
+
+        /// <summary>
         /// Converts the current instance to string.
         /// </summary>
-        public static implicit operator string (Attribute instance)
+        public static implicit operator string(Attribute instance)
         {
             return instance.ToString();
         }

--- a/src/CodeModel/CodeModel/AttributeArgument.cs
+++ b/src/CodeModel/CodeModel/AttributeArgument.cs
@@ -1,0 +1,12 @@
+﻿using Typewriter.CodeModel.Attributes;
+
+namespace Typewriter.CodeModel
+{
+    [Context("AttributeArguments", "AttributeArguments")]
+    public abstract class AttributeArgument : Item
+    {
+        public abstract Type Type { get; }
+        public abstract Type TypeValue { get; }
+        public abstract object Value { get; }
+    }
+}

--- a/src/CodeModel/Typewriter.CodeModel.XML
+++ b/src/CodeModel/Typewriter.CodeModel.XML
@@ -34,6 +34,11 @@
             The value of the attribute as string.
             </summary>
         </member>
+        <member name="P:Typewriter.CodeModel.Attribute.Arguments">
+            <summary>
+            The arguments of the attribute.
+            </summary>
+        </member>
         <member name="M:Typewriter.CodeModel.Attribute.op_Implicit(Typewriter.CodeModel.Attribute)~System.String">
             <summary>
             Converts the current instance to string.

--- a/src/CodeModel/Typewriter.CodeModel.csproj
+++ b/src/CodeModel/Typewriter.CodeModel.csproj
@@ -48,6 +48,7 @@
     <Compile Include="CodeModel\Attribute.cs" />
     <Compile Include="Attributes\ContextAttribute.cs" />
     <Compile Include="Attributes\PropertyAttribute.cs" />
+    <Compile Include="CodeModel\AttributeArgument.cs" />
     <Compile Include="CodeModel\Class.cs" />
     <Compile Include="CodeModel\Constant.cs" />
     <Compile Include="CodeModel\Delegate.cs" />

--- a/src/Metadata/Interfaces/IAttributeArgumentMetadata.cs
+++ b/src/Metadata/Interfaces/IAttributeArgumentMetadata.cs
@@ -1,0 +1,11 @@
+﻿namespace Typewriter.Metadata.Interfaces
+{
+    public interface IAttributeArgumentMetadata
+    {
+        ITypeMetadata Type { get; }
+
+        ITypeMetadata TypeValue { get; }
+
+        object Value { get; }
+    }
+}

--- a/src/Metadata/Interfaces/IAttributeMetadata.cs
+++ b/src/Metadata/Interfaces/IAttributeMetadata.cs
@@ -5,5 +5,6 @@ namespace Typewriter.Metadata.Interfaces
     public interface IAttributeMetadata : INamedItem
     {
         string Value { get; }
+        IEnumerable<IAttributeArgumentMetadata> Arguments { get; }
     }
 }

--- a/src/Metadata/Typewriter.Metadata.csproj
+++ b/src/Metadata/Typewriter.Metadata.csproj
@@ -46,6 +46,7 @@
     <Compile Include="..\Typewriter\Properties\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Interfaces\IAttributeArgumentMetadata.cs" />
     <Compile Include="Interfaces\IAttributeMetadata.cs" />
     <Compile Include="Interfaces\IClassMetadata.cs" />
     <Compile Include="Interfaces\IConstantMetadata.cs" />

--- a/src/Roslyn/RoslynAttributeMetadata.cs
+++ b/src/Roslyn/RoslynAttributeMetadata.cs
@@ -39,12 +39,15 @@ namespace Typewriter.Metadata.Roslyn
 
             if (name.EndsWith("Attribute"))
                 name = name.Substring(0, name.Length - 9);
+
+            this.Arguments = a.ConstructorArguments.Concat(a.NamedArguments.Select(p=>p.Value)).Select(p => new RoslynAttrubuteArgumentMetadata(p));
         }
 
         public string DocComment => symbol.GetDocumentationCommentXml();
         public string Name => name;
         public string FullName => symbol.ToDisplayString();
         public string Value => value;
+        public IEnumerable<IAttributeArgumentMetadata> Arguments { get; private set; }
 
         public static IEnumerable<IAttributeMetadata> FromAttributeData(IEnumerable<AttributeData> attributes)
         {

--- a/src/Roslyn/RoslynAttrubuteParameterMetadata.cs
+++ b/src/Roslyn/RoslynAttrubuteParameterMetadata.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.CodeAnalysis;
+using System.Linq;
+using Typewriter.Metadata.Interfaces;
+
+namespace Typewriter.Metadata.Roslyn
+{
+    public class RoslynAttrubuteArgumentMetadata : IAttributeArgumentMetadata
+    {
+        private TypedConstant typeConstant;
+
+        public RoslynAttrubuteArgumentMetadata(TypedConstant typeConstant)
+        {
+            this.typeConstant = typeConstant;
+        }
+
+        public ITypeMetadata Type => RoslynTypeMetadata.FromTypeSymbol(typeConstant.Type);
+
+        public ITypeMetadata TypeValue => typeConstant.Kind == TypedConstantKind.Type ? RoslynTypeMetadata.FromTypeSymbol((INamedTypeSymbol)typeConstant.Value) : null;
+        public object Value => typeConstant.Kind == TypedConstantKind.Array ? typeConstant.Values.Select(prop => prop.Value).ToArray() : typeConstant.Value;
+    }
+}

--- a/src/Roslyn/Typewriter.Metadata.Roslyn.csproj
+++ b/src/Roslyn/Typewriter.Metadata.Roslyn.csproj
@@ -165,6 +165,7 @@
     </Compile>
     <Compile Include="Extensions.cs" />
     <Compile Include="RoslynAttributeMetadata.cs" />
+    <Compile Include="RoslynAttrubuteParameterMetadata.cs" />
     <Compile Include="RoslynClassMetadata.cs" />
     <Compile Include="RoslynConstantMetadata.cs" />
     <Compile Include="RoslynEnumMetadata.cs" />

--- a/src/Tests/CodeModel/AttributeArgumentTests.cs
+++ b/src/Tests/CodeModel/AttributeArgumentTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Linq;
+using Should;
+using Typewriter.CodeModel;
+using Typewriter.Tests.CodeModel.Support;
+using Typewriter.Tests.TestInfrastructure;
+using Xunit;
+
+namespace Typewriter.Tests.CodeModel
+{
+    [Trait("CodeModel", "AttributeArguments"), Collection(nameof(RoslynFixture))]
+    public class RoslynAttributeArgumentTests : AttributeArgumentTests
+    {
+        public RoslynAttributeArgumentTests(RoslynFixture fixture) : base(fixture)
+        {
+        }
+    }
+
+    public abstract class AttributeArgumentTests : TestBase
+    {
+        private readonly Class classInfo;
+
+        protected AttributeArgumentTests(ITestFixture fixture) : base(fixture)
+        {
+            var fileInfo = GetFile(@"Tests\CodeModel\Support\AttributeInfo.cs");
+            classInfo = fileInfo.Classes.First(c => c.Name == nameof(AttributeTestClass));
+        }
+
+        [Fact]
+        public void Expect_attributes_with_no_parameters_to_have_an_empty_value()
+        {
+            var propertyInfo = classInfo.Properties.First(p => p.Name == "NoParameters");
+            var attributeInfo = propertyInfo.Attributes.First();
+
+            attributeInfo.Arguments.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Expect_attributes_with_string_parameter_to_have_a_string_value()
+        {
+            var propertyInfo = classInfo.Properties.First(p => p.Name == "StringParameter");
+            var attributeInfo = propertyInfo.Attributes.First();
+
+            var attributeArgument = attributeInfo.Arguments.Single();
+            attributeArgument.Value.ShouldEqual("parameter");
+            attributeArgument.Type.OriginalName.ShouldEqual("string");
+        }
+
+        [Fact]
+        public void Expect_attributes_with_int_parameter_to_have_an_integer_value()
+        {
+            var propertyInfo = classInfo.Properties.First(p => p.Name == "IntParameter");
+            var attributeInfo = propertyInfo.Attributes.First();
+
+            var attributeArgument = attributeInfo.Arguments.Single();
+            attributeArgument.Value.ShouldEqual(1);
+            attributeArgument.Type.OriginalName.ShouldEqual("int");
+        }
+
+        [Fact]
+        public void Expect_attributes_with_int_and_named_parameter_to_have_a_proper_value()
+        {
+            var propertyInfo = classInfo.Properties.First(p => p.Name == "IntAndNamedParameter");
+            var attributeInfo = propertyInfo.Attributes.First();
+
+            var integerArgument = attributeInfo.Arguments.First();
+            integerArgument.Value.ShouldEqual(2);
+            integerArgument.Type.OriginalName.ShouldEqual("int");
+
+            var stringArgument = attributeInfo.Arguments.Skip(1).First();
+            stringArgument.Value.ShouldEqual("parameter");
+            stringArgument.Type.OriginalName.ShouldEqual("string");
+        }
+
+        [Fact]
+        public void Expect_attributes_with_params_parameter_to_have_a_proper_value()
+        {
+            var propertyInfo = classInfo.Properties.First(p => p.Name == "ParamsParameter");
+            var attributeInfo = propertyInfo.Attributes.First();
+
+            var stringArgument1 = attributeInfo.Arguments.First();
+            stringArgument1.Value.ShouldEqual(new object[] { "parameter1", "parameter2" });
+            stringArgument1.Type.OriginalName.ShouldEqual("string[]");
+
+        }
+
+        [Fact]
+        public void Expect_attributes_with_string_and_params_parameter_to_have_a_proper_value()
+        {
+            var propertyInfo = classInfo.Properties.First(p => p.Name == "IntAndParamsParameter");
+            var attributeInfo = propertyInfo.Attributes.First();
+
+            var integerArgument = attributeInfo.Arguments.First();
+            integerArgument.Value.ShouldEqual(1);
+            integerArgument.Type.OriginalName.ShouldEqual("int");
+
+            var stringArgument = attributeInfo.Arguments.Skip(1).First();
+            stringArgument.Value.ShouldEqual(new object[] { "parameter" });
+            stringArgument.Type.OriginalName.ShouldEqual("string[]");
+        }
+
+        [Fact]
+        public void Expect_attributes_with_type_parameter_to_have_a_proper_value()
+        {
+            var propertyInfo = classInfo.Properties.First(p => p.Name == "Type");
+            var attributeInfo = propertyInfo.Attributes.First();
+
+            var integerArgument = attributeInfo.Arguments.Single();
+            integerArgument.TypeValue.Name.ShouldEqual("AttributeTestClass");
+            integerArgument.Type.OriginalName.ShouldEqual("Type");
+        }
+    }
+}

--- a/src/Tests/CodeModel/Support/AttributeInfo.cs
+++ b/src/Tests/CodeModel/Support/AttributeInfo.cs
@@ -26,6 +26,10 @@ namespace Typewriter.Tests.CodeModel.Support
         public AttributeInfoAttribute(int parameter, params string[] parameters)
         {
         }
+
+        public AttributeInfoAttribute(Type parameter)
+        {
+        }
     }
 
     public class AttributeTestClass
@@ -47,5 +51,8 @@ namespace Typewriter.Tests.CodeModel.Support
 
         [AttributeInfo(1, "parameter")]
         public string IntAndParamsParameter { get; set; }
+
+        [AttributeInfo(typeof(AttributeTestClass))]
+        public string Type { get; set; }
     }
 }

--- a/src/Tests/Typewriter.Tests.csproj
+++ b/src/Tests/Typewriter.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="..\Typewriter\Properties\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="CodeModel\AttributeArgumentTests.cs" />
     <Compile Include="CodeModel\AttributeTests.cs" />
     <Compile Include="CodeModel\PartialClassTests.cs" />
     <Compile Include="CodeModel\ConstantTests.cs" />

--- a/src/Typewriter/CodeModel/Implementation/AttributeImpl.cs
+++ b/src/Typewriter/CodeModel/Implementation/AttributeImpl.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Typewriter.CodeModel.Collections;
+using Typewriter.CodeModel.Typescript.Implementation;
 using Typewriter.Metadata.Interfaces;
 using static Typewriter.CodeModel.Helpers;
 
@@ -22,6 +23,8 @@ namespace Typewriter.CodeModel.Implementation
         public override string Name => _metadata.Name.TrimStart('@');
         public override string FullName => _metadata.FullName;
         public override string Value => GetValue(_metadata.Value);
+
+        public override IEnumerable<AttributeArgument> Arguments => _metadata.Arguments.Select(argument => new AttributeArgumentImpl(argument, this));
 
         private static string GetValue(string value)
         {

--- a/src/Typewriter/CodeModel/Implementation/AttributeParameterImpl.cs
+++ b/src/Typewriter/CodeModel/Implementation/AttributeParameterImpl.cs
@@ -1,0 +1,22 @@
+﻿using Typewriter.CodeModel.Implementation;
+using Typewriter.Metadata.Interfaces;
+
+namespace Typewriter.CodeModel.Typescript.Implementation
+{
+    public class AttributeArgumentImpl : AttributeArgument
+    {
+        private IAttributeArgumentMetadata _metadata;
+        private readonly Item parent;
+
+        public AttributeArgumentImpl(IAttributeArgumentMetadata metadata, Item parent)
+        {
+            _metadata = metadata;
+            this.parent = parent;
+        }
+        public override Type Type => TypeImpl.FromMetadata(_metadata.Type, parent);
+
+        public override Type TypeValue => TypeImpl.FromMetadata(_metadata.TypeValue, parent);
+
+        public override object Value => _metadata.Value;
+    }
+}

--- a/src/Typewriter/Typewriter.csproj
+++ b/src/Typewriter/Typewriter.csproj
@@ -276,6 +276,7 @@
     <Compile Include="CodeModel\Collections\TypeParameterCollectionImpl.cs" />
     <Compile Include="CodeModel\Configuration\ProjectHelpers.cs" />
     <Compile Include="CodeModel\Configuration\SettingsImpl.cs" />
+    <Compile Include="CodeModel\Implementation\AttributeParameterImpl.cs" />
     <Compile Include="CodeModel\Implementation\DocComment.cs" />
     <Compile Include="CodeModel\Implementation\EventImpl.cs" />
     <Compile Include="CodeModel\Implementation\DelegateImpl.cs" />


### PR DESCRIPTION
Hi @frhagn,

I have added support for getting arguments passed to attribute - especially typeof arguments. It will fix common issue related to Produces attribute in .net core web api https://github.com/frhagn/Typewriter/issues/255. 