### PR TITLE
Update manifest for VS2019

### DIFF
--- a/src/Typewriter/source.extension.vsixmanifest
+++ b/src/Typewriter/source.extension.vsixmanifest
@@ -13,9 +13,8 @@
         <Tags>TypeScript, Code Generation, Templates, Web API, MVC, Typewriter</Tags>
     </Metadata>
     <Installation InstalledByMsi="false">
-        <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[12.0,)" Id="Microsoft.VisualStudio.Pro" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -40,6 +39,6 @@
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="System.Reflection.Metadata.dll" AssemblyName="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,16.0)" DisplayName="C# and Visual Basic" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,)" DisplayName="C# and Visual Basic" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Changed manifest to allow VS 2019 installation. 

- Dropped Enterprise version because Community version works for all versions.
- Left Pro version in because it referenced earlier version (12 instead of 14).