### PR TITLE
Fixes issue #327

### DIFF
--- a/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
+++ b/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
@@ -195,9 +195,13 @@ namespace Typewriter.Extensions.WebApi
             var parameter = method.Parameters.FirstOrDefault(p => p.Name == name);
             if (parameter != null)
             {
-                if (parameter.Type.Name == "string" || parameter.Type.IsDate)
+                if (parameter.Type.Name == "string")
                 {
                     return $"encodeURIComponent({name})";
+                }
+                if (parameter.Type.IsDate)
+                {
+                    return $"encodeURIComponent(String({name}))";
                 }
             }
 

--- a/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
+++ b/src/CodeModel/Extensions/WebApi/UrlExtensions.cs
@@ -70,9 +70,9 @@ namespace Typewriter.Extensions.WebApi
                 {
                     route = routePrefix ?? route;
                 }
-                else if (value.StartsWith("~"))
+                else if (value.StartsWith("~/"))
                 {
-                    route = value.Remove(0, 1);
+                    route = value.Remove(0, 2);
                 }
                 else if (routePrefix == null)
                 {
@@ -83,7 +83,7 @@ namespace Typewriter.Extensions.WebApi
                     route = string.Concat(routePrefix, "/", value);
                 }
             }
-            else if(routePrefix != null)
+            else if (routePrefix != null)
             {
                 route = string.Concat(routePrefix, "/", route);
             }
@@ -193,9 +193,12 @@ namespace Typewriter.Extensions.WebApi
         internal static string GetParameterValue(Method method, string name)
         {
             var parameter = method.Parameters.FirstOrDefault(p => p.Name == name);
-            if (parameter?.Type.Name == "string")
+            if (parameter != null)
             {
-                return $"encodeURIComponent({name})";
+                if (parameter.Type.Name == "string" || parameter.Type.IsDate)
+                {
+                    return $"encodeURIComponent({name})";
+                }
             }
 
             return name;


### PR DESCRIPTION
As a bonus I also fixed an extra slash that is included in the $Url when the route of the c# method is "rebased" from the current RoutePrefix, as in "~/api/whatever".
Before the fix, that would be translated to "//api/whatever". Now it would be translated to "/api/whatever", just like other urls.