### PR TITLE
Added IsVirtual to Property metadata (fixes #267)

### DIFF
--- a/src/CodeDom/CodeDomPropertyMetadata.cs
+++ b/src/CodeDom/CodeDomPropertyMetadata.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.CodeDom;
+using System.Collections.Generic;
 using System.Linq;
 using EnvDTE;
 using EnvDTE80;
@@ -25,6 +26,9 @@ namespace Typewriter.Metadata.CodeDom
         public bool IsAbstract => 
             (codeProperty.Getter != null && codeProperty.Getter.MustImplement) || 
             (codeProperty.Setter != null && codeProperty.Setter.MustImplement);
+        public bool IsVirtual => codeProperty.Attributes
+            .OfType<MemberAttributes>()
+            .Any(a => a == MemberAttributes.Final);
         public IEnumerable<IAttributeMetadata> Attributes => CodeDomAttributeMetadata.FromCodeElements(codeProperty.Attributes);
         public ITypeMetadata Type => CodeDomTypeMetadata.FromCodeElement(codeProperty, file);
         

--- a/src/CodeModel/CodeModel/Property.cs
+++ b/src/CodeModel/CodeModel/Property.cs
@@ -39,6 +39,11 @@ namespace Typewriter.CodeModel
         public abstract bool IsAbstract { get; }
 
         /// <summary>
+        /// Determines if the property is virtual.
+        /// </summary>
+        public abstract bool IsVirtual { get; }
+
+        /// <summary>
         /// The name of the property (camelCased).
         /// </summary>
         public abstract string name { get; }

--- a/src/CodeModel/Typewriter.CodeModel.XML
+++ b/src/CodeModel/Typewriter.CodeModel.XML
@@ -964,6 +964,11 @@
             Determines if the property is abstract.
             </summary>
         </member>
+        <member name="P:Typewriter.CodeModel.Property.IsVirtual">
+            <summary>
+            Determines if the property is virtual.
+            </summary>
+        </member>
         <member name="P:Typewriter.CodeModel.Property.name">
             <summary>
             The name of the property (camelCased).

--- a/src/Metadata/Interfaces/IPropertyMetadata.cs
+++ b/src/Metadata/Interfaces/IPropertyMetadata.cs
@@ -5,6 +5,7 @@ namespace Typewriter.Metadata.Interfaces
     public interface IPropertyMetadata : IFieldMetadata
     {
         bool IsAbstract { get; }
+        bool IsVirtual { get; }
         bool HasGetter { get; }
         bool HasSetter { get; }
     }

--- a/src/Roslyn/RoslynPropertyMetadata.cs
+++ b/src/Roslyn/RoslynPropertyMetadata.cs
@@ -21,6 +21,7 @@ namespace Typewriter.Metadata.Roslyn
         public IEnumerable<IAttributeMetadata> Attributes => RoslynAttributeMetadata.FromAttributeData(symbol.GetAttributes());
         public ITypeMetadata Type => RoslynTypeMetadata.FromTypeSymbol(symbol.Type);
         public bool IsAbstract => symbol.IsAbstract;
+        public bool IsVirtual => symbol.IsVirtual;
         public bool HasGetter => symbol.GetMethod != null && symbol.GetMethod.DeclaredAccessibility == Accessibility.Public;
         public bool HasSetter => symbol.SetMethod != null && symbol.SetMethod.DeclaredAccessibility == Accessibility.Public;
         

--- a/src/Tests/CodeModel/ClassMetadataTests.cs
+++ b/src/Tests/CodeModel/ClassMetadataTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using Should;
+using Typewriter.CodeModel;
+using Typewriter.Tests.TestInfrastructure;
+using Xunit;
+using Typewriter.CodeModel.Configuration;
+using Typewriter.Configuration;
+using Typewriter.Tests.CodeModel.Support;
+
+namespace Typewriter.Tests.CodeModel
+{
+    [Trait("CodeModel", "PartialClasses"), Collection(nameof(RoslynFixture))]
+    public class RoslynClassMetadataTests : TestBase
+    {
+        public RoslynClassMetadataTests(RoslynFixture fixture) : base(fixture)
+        {
+        }
+
+        private File GetFile(PartialRenderingMode partialRenderingMode)
+        {
+            var settings = new SettingsImpl(null) { PartialRenderingMode = partialRenderingMode };
+            return GetFile(@"Tests\CodeModel\Support\GeneratedClass.cs", settings);
+        }
+        
+        [Fact]
+        public void Expect_all_properties_to_exist()
+        {
+            var fileInfo = GetFile(PartialRenderingMode.Combined);
+            var classInfo = fileInfo.Classes.First();
+            var properties = typeof(GeneratedClass).GetProperties();
+
+            classInfo.Properties.All(op => properties.Any(cp => op.Name == cp.Name))
+                .ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Expect_property_attributes_to_exist()
+        {
+            var fileInfo = GetFile(PartialRenderingMode.Combined);
+            var classInfo = fileInfo.Classes.First();
+
+            classInfo.Properties.Any(propertyInfo =>
+                propertyInfo.Attributes.Any(a => a.Name == "Key")
+            ).ShouldBeTrue();
+
+            var hasDisplayProperty = classInfo.Properties.Any(propertyInfo =>
+                propertyInfo.Attributes
+                    .Any(a =>
+                        a.Name == "Display"
+                        && a.Arguments.Any(arg =>
+                            string.Equals(
+                                arg.Value.ToString(), 
+                                "NewPropertyName",
+                                StringComparison.InvariantCultureIgnoreCase
+                            )
+                        )
+                    )
+            );
+            hasDisplayProperty.ShouldBeTrue();
+        }
+    }
+}

--- a/src/Tests/CodeModel/Support/GeneratedClass.cs
+++ b/src/Tests/CodeModel/Support/GeneratedClass.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Typewriter.Tests.CodeModel.Support
+{
+    public partial class GeneratedClass
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public DateTime DateCreated { get; set; }
+    }
+}

--- a/src/Tests/CodeModel/Support/GeneratedClass2.cs
+++ b/src/Tests/CodeModel/Support/GeneratedClass2.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Typewriter.Tests.CodeModel.Support
+{
+    [MetadataType(typeof(GeneratedClassMetadata))]
+    public partial class GeneratedClass
+    {
+        internal sealed class GeneratedClassMetadata
+        {
+            [Key]
+            public int Id { get; set; }
+            [Display(Name = "NewPropertyName")]
+            public string Title { get; set; }
+        }
+    }
+}

--- a/src/Typewriter/CodeModel/Implementation/PropertyImpl.cs
+++ b/src/Typewriter/CodeModel/Implementation/PropertyImpl.cs
@@ -24,6 +24,7 @@ namespace Typewriter.CodeModel.Implementation
         public override bool HasGetter => _metadata.HasGetter;
         public override bool HasSetter => _metadata.HasSetter;
         public override bool IsAbstract => _metadata.IsAbstract;
+        public override bool IsVirtual => _metadata.IsVirtual;
 
         private AttributeCollection _attributes;
         public override AttributeCollection Attributes => _attributes ?? (_attributes = AttributeImpl.FromMetadata(_metadata.Attributes, this));


### PR DESCRIPTION
Tested in Visual Studio 2015 and 2019 to filter virtual properties from a generated class.