### PR TITLE
Fix for nullable Types

### DIFF
--- a/src/Roslyn/RoslynTypeMetadata.cs
+++ b/src/Roslyn/RoslynTypeMetadata.cs
@@ -98,7 +98,7 @@ namespace Typewriter.Metadata.Roslyn
         }
 
         public bool IsEnum => symbol.TypeKind == TypeKind.Enum;
-        public bool IsEnumerable => symbol.ToDisplayString() != "string" && (
+        public bool IsEnumerable => (symbol.ToDisplayString() != "string" && symbol.ToDisplayString() != "string?") && (
             symbol.TypeKind == TypeKind.Array ||
             symbol.ToDisplayString() == "System.Collections.IEnumerable" ||
             symbol.AllInterfaces.Any(i => i.ToDisplayString() == "System.Collections.IEnumerable"));


### PR DESCRIPTION
With C# 9, nullable strings were producing string[] instead of string. One line of code fixes this by also checking for string? as the display string.